### PR TITLE
Fix package

### DIFF
--- a/bibtex-utils.el
+++ b/bibtex-utils.el
@@ -46,6 +46,7 @@
 ;; Keywords ;;
 ;;;;;;;;;;;;;;
 
+(defvar bu-keywords-values)
 (make-variable-buffer-local 'bu-keywords-values)
 (make-obsolete-variable 'bibtex-keywords-values "Bibtex-utils \n
 functions and variables are now prefixed with bu-, not bibtex-")

--- a/bibtex-utils.el
+++ b/bibtex-utils.el
@@ -40,6 +40,7 @@
 ;;
 ;;; Code:
 (require 'bibtex)
+(require 'reftex)
 
 ;;;;;;;;;;;;;;
 ;; Keywords ;;


### PR DESCRIPTION
- load ref-mode
- declare missing variable declaration

There are some byte-compile warnings about this.

```
In bu-parse-keywords-values:
bibtex-utils.el:53:9:Warning: assignment to free variable `bu-keywords-values'

In bu-make-field-keywords:
bibtex-utils.el:106:56:Warning: reference to free variable
    `bu-keywords-values'
bibtex-utils.el:112:25:Warning: assignment to free variable
    `bu-keywords-values'

In bu-jump-to-doc:
bibtex-utils.el:176:48:Warning: reference to free variable
    `reftex-default-bibliography'

In end of data:
bibtex-utils.el:232:1:Warning: the following functions are not known to be defined:
    reftex-pop-to-bibtex-entry, reftex-this-word,
    reftex-get-bibfile-list
```
